### PR TITLE
Upgrade to node v14 from v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Andrew Lilley",
   "license": "MIT",
   "engines": {
-    "node": "12.17.0"
+    "node": "14.18.2"
   },
   "scripts": {
     "serve": "live-server public/",


### PR DESCRIPTION
 This is some demo code from a training course so it is not a live project. Upgrading to v16 would mean looking into some of the other packages installed for the project which I am not going to do right now. This upgrade will keep the demo running through to 2023.